### PR TITLE
Set 6.5.0 as last version for Angular 4.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Latest version available for each version of Angular
 
 | ngx-toastr   | Angular |
 | ------------ | ------- |
-| 6.4.1-beta.0 | 4.x     |
+| 6.5.0 | 4.x     |
 | 8.10.2       | 5.x     |
 | 10.0.4       | 8.x 7.x 6.x |
 


### PR DESCRIPTION
cf. peerDependencies field for version 6.5.0 at https://registry.npmjs.org/ngx-toastr/